### PR TITLE
Add SimpleTest support

### DIFF
--- a/data/webapps/cruisecontrol/main.jsp
+++ b/data/webapps/cruisecontrol/main.jsp
@@ -153,7 +153,9 @@
             </cruisecontrol:tab>
 
             <%-- phpUnderControl 11 --%>
-
+            <cruisecontrol:tab name="simpletest" label="Simpletest">
+              <%@ include file="simpletest.jsp" %>
+            </cruisecontrol:tab>
           </td>
         </tr>
       </cruisecontrol:tabsheet>

--- a/data/webapps/cruisecontrol/simpletest.jsp
+++ b/data/webapps/cruisecontrol/simpletest.jsp
@@ -1,8 +1,7 @@
-<?xml version="1.0"?>
-<!--********************************************************************************
+<%--********************************************************************************
  * CruiseControl, a Continuous Integration Toolkit
  * Copyright (c) 2001, ThoughtWorks, Inc.
- * 651 W Washington Ave. Suite 500
+ * 200 E. Randolph, 25th Floor
  * Chicago, IL 60601 USA
  * All rights reserved.
  *
@@ -34,34 +33,8 @@
  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ********************************************************************************-->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+ ********************************************************************************--%>
+<%@ taglib uri="/WEB-INF/cruisecontrol-jsp11.tld" prefix="cruisecontrol"%>
 
-    <xsl:import href="maven.xsl"/>
-    <xsl:import href="phpmd.xsl"/>
-    <xsl:import href="errors.xsl"/>
-    <xsl:import href="phpdoc.xsl"/>
-    <xsl:import href="phpcs.xsl"/>
-    <xsl:import href="phpunit.xsl"/>
-    <xsl:import href="fittests.xsl"/>
-    <xsl:import href="modifications.xsl"/>
-    <xsl:import href="cvstagdiff.xsl"/>
-    <xsl:import href="distributables.xsl"/>
-    <xsl:import href="simpletest.xsl"/>
+<cruisecontrol:xsl xslFile="/xsl/simpletest-details.xsl"/>
 
-    <xsl:output method="html" />
-
-    <xsl:variable name="cruisecontrol.list" select="."/>
-
-    <xsl:template match="/">
-        <p><xsl:apply-templates select="$cruisecontrol.list" mode="errors"/></p>
-        <p><xsl:apply-templates select="$cruisecontrol.list" mode="unittests"/></p>
-        <p><xsl:apply-templates select="$cruisecontrol.list" mode="maven"/></p>
-        <p><xsl:apply-templates select="$cruisecontrol.list" mode="modifications"/></p>
-        <p><xsl:apply-templates select="$cruisecontrol.list" mode="cvstagdiff"/></p>
-        <p><xsl:apply-templates select="$cruisecontrol.list" mode="distributables"/></p>
-        <p><xsl:apply-templates select="$cruisecontrol.list" mode="pmd"/></p>
-        <p><xsl:apply-templates select="$cruisecontrol.list" mode="checkstyle" /></p>
-        <p><xsl:apply-templates select="$cruisecontrol.list" mode="phpdoc" /></p>
-    </xsl:template>
-</xsl:stylesheet>

--- a/data/webapps/cruisecontrol/xsl/simpletest-details.xsl
+++ b/data/webapps/cruisecontrol/xsl/simpletest-details.xsl
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" >
+  <xsl:output method="html" encoding="UTF-8" indent="yes"/>
+
+  <xsl:template match="/">
+    <tr>
+      <td>
+        <style>
+          #simpletest-result-set
+          {
+            background : white !important;
+            margin : 2em;
+            height : 0 !important;
+          }
+
+          #simpletest-result-set h1
+          {
+            margin : 0.5em;
+            padding : 0.2em 0.5em;
+            font-size : 2em !important;
+          }
+
+          .test-case
+          {
+            background : white !important;
+            height : 10em !important;
+          }
+
+          .test-case h3
+          {
+            padding-left : 2em;
+          }
+
+          .module
+          {
+            background : white !important;
+            border : solid thin black;
+          }
+
+          .pass, .fail, .exception
+          {
+            background : white !important;
+            padding-left : 2em;
+          }
+        </style>
+
+        <xsl:apply-templates select="//run" />
+      </td>
+    </tr>
+  </xsl:template>
+
+  <xsl:template match="run">
+    <div id="simpletest-result-set">
+      <h1>SimpleTest Result Set</h1>
+
+      <ul><xsl:apply-templates select="//group/name[not(.=following::group/name)]" /></ul>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="group/name">
+    <li class="module">
+      <h2><xsl:value-of select="." /></h2>
+
+      <xsl:variable name="group_name" select="." />
+      <xsl:apply-templates select="//group[name=$group_name]/case" />
+    </li>
+  </xsl:template>
+
+  <!-- xsl:template match="group">
+    <li class="module">
+      <h2><xsl:value-of select="name" /></h2>
+      <xsl:apply-templates select="case" />
+    </li>
+  </xsl:template -->
+
+  <xsl:template match="case">
+    <div class="test-case">
+      <h3><xsl:value-of select="name" /></h3>
+
+      <div class="pass">
+        <xsl:text>Pass case: </xsl:text>
+        <xsl:value-of select="count(test/pass)" />
+      </div>
+
+      <div class="fail">
+        <xsl:text>Fail case: </xsl:text>
+        <xsl:value-of select="count(test/fail)" />
+      </div>
+
+      <div class="exception">
+        <xsl:text>Exception(s): </xsl:text>
+        <xsl:value-of select="count(test/exception)" />
+        <xsl:value-of select="exception" />
+      </div>
+    </div>
+  </xsl:template>
+
+</xsl:stylesheet>
+

--- a/data/webapps/cruisecontrol/xsl/simpletest.xsl
+++ b/data/webapps/cruisecontrol/xsl/simpletest.xsl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" >
+  <xsl:output method="html" encoding="UTF-8" indent="yes"/>
+
+  <xsl:template match="/" mode="simpletest">
+    <table class="result" align="center">
+      <thead>
+        <tr>
+          <th colspan="4">
+            SimpleTest Unit Tests: (<xsl:value-of select="sum( //case/pass | //case/fail )" />)
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td colspan="4">
+            Total Pass case(s): (<xsl:value-of select="sum(//case/pass)" />)
+          </td>
+        </tr>
+        <tr>
+          <td colspan="4">
+            Total Fail case(s): (<xsl:value-of select="sum(//case/fail)" />)
+          </td>
+        </tr>
+        <tr>
+          <td colspan="4">
+            Total Exception(s): (<xsl:value-of select="sum(//case/exception)" />)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </xsl:template>
+
+</xsl:stylesheet>
+


### PR DESCRIPTION
This perhaps isn't the prettiest implementation possible, but this commit incorporates an updated version of the patch suggested here:

http://demo.codesetter.com/phpundercontrol-drupal-6-n-7

To configure it, write a test harness that uses the `XmlReporter` class; something along the lines of:

```
<?php
// Includes...
$reporter = new XmlReporter;
$harness = new TestSuite;
$harness->run($reporter);
```

Now edit CruiseControl's `config.xml` so that the `test-result.xml` file gets merged into the resulting build log. We need to do this so that the log can be parsed to generate the SimpleTest page for each build:

```
<log>
    <merge file="projects/${project.name}" />
</log>
```

Finally, add a target to your `build.xml`, and call it from the the target CruiseControl is calling:

```
<target name="test" description="Run the test suite">
    <exec executable="php" dir="${basedir}" output="${basedir}/build/logs/test-results.xml">
        <arg value="path/to/harness.php" />
    </exec>
</target>
```

I need to work on displaying failed tests, though I'm not particularly knowledgeable about XSLT, so this may take me a few days. For a quick overview, this code should work fine, however.
